### PR TITLE
docs: update README.md with correct repository links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 A Highly Customizable Advanced Admin Panel for Go (Still in development a lot) GORM Integration
 
-[![go report card](https://goreportcard.com/badge/github.com/go-advanced-admin/web-echo "go report card")](https://goreportcard.com/report/github.com/go-advanced-admin/web-echo)
-[![Go](https://github.com/go-advanced-admin/web-echo/actions/workflows/tests.yml/badge.svg)](https://github.com/go-advanced-admin/web-echo/actions/workflows/tests.yml)
+[![go report card](https://goreportcard.com/badge/github.com/go-advanced-admin/orm-gorm "go report card")](https://goreportcard.com/report/github.com/go-advanced-admin/orm-gorm)
+[![Go](https://github.com/go-advanced-admin/orm-gorm/actions/workflows/tests.yml/badge.svg)](https://github.com/go-advanced-admin/orm-gorm/actions/workflows/tests.yml)
 [![MIT license](https://img.shields.io/badge/license-MIT-brightgreen.svg)](https://opensource.org/licenses/MIT)
-[![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-blue?logo=go&logoColor=white)](https://pkg.go.dev/github.com/go-advanced-admin/web-echo?tab=doc)
+[![Go.Dev reference](https://img.shields.io/badge/go.dev-reference-blue?logo=go&logoColor=white)](https://pkg.go.dev/github.com/go-advanced-admin/orm-gorm?tab=doc)
 
 ## Installation
 


### PR DESCRIPTION
Updated the README.md to reflect the correct repository URLs for badges and references. This ensures that users are directed to the appropriate resources related to the 'orm-gorm' repository instead of the previously incorrect 'web-echo' repository. This change improves the accuracy and reliability of the documentation.